### PR TITLE
riscv-plic.adoc: fix image paths and  add more descriptive alt-texts

### DIFF
--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -1,4 +1,5 @@
 # *RISC-V Platform-Level Interrupt Controller Specification*
+:imagesdir: ./Images/
 
 ## Copyright and license information
 
@@ -24,7 +25,7 @@ This specification defines the general PLIC architecture and operation parameter
 The PLIC which claimed as PLIC-Compliant standard PLIC should follow the
 implementations mentioned in sections below.
 
-image::https://github.com/riscv/riscv-plic-spec/blob/UNIX-PLIC-Spec/Images/PLIC.jpg[GitHub][1000,643]
+image::PLIC.jpg[PLIC Scheme][1000,643]
 
 #### Figure 1 RISC-V PLIC Interrupt Architecture Block Diagram
 
@@ -54,7 +55,7 @@ General PLIC operation parameter register blocks are defined in this spec, those
 
 Below is the figure of PLIC Operation Parameter Block Diagram,
 
-image::https://github.com/riscv/riscv-plic-spec/blob/UNIX-PLIC-Spec/Images/PLICArch.jpg[GitHub]
+image::PLICArch.jpg[PLIC Architecture Block Diagram]
 
 #### Figure 2 PLIC Operation Parameter Block Diagram
 


### PR DESCRIPTION
Change image paths to relative paths and add more descriptive alt-texts.