### PR TITLE
add some description for context

### DIFF
--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -177,7 +177,12 @@ to the specific privilege mode in the specific Hart of specific RISC-V processor
 instance. How PLIC organizes interrupts for the contexts (Hart and privilege mode) 
 is out of RISC-V PLIC specification scope, however it must be spec-out in vendor's 
 PLIC specification. +
- +
+	
+	A hart context is a privilege mode in a hardware execution thread. For example,
+	in an 4 core system with 2-way SMT, you have 8 harts and probably at least two
+	priviledge modes per hart: machine mode and supervisor mode.
+	(ref: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/Documentation/devicetree/bindings/interrupt-controller/sifive%2Cplic-1.0.0.yaml) 
+
 The base address of Interrupt Enable Bits block within PLIC Memory Map region is fixed at 0x002000. +
  +
 [cols="15%,20%,20%,45%"]

--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -184,7 +184,7 @@ instance. For example, in an 4-core system with 2-way SMT, you have 8 harts and 
 at least two privilege modes per hart: machine mode and supervisor mode.
 (ref: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/Documentation/devicetree/bindings/interrupt-controller/sifive%2Cplic-1.0.0.yaml)
 
-How PLIC organizes interrupts for the contexts (Hart and privilege mode) 
+However PLIC organizes interrupts for the contexts (Hart and privilege mode) 
 is out of RISC-V PLIC specification scope, however it must be spec-out in vendor's 
 PLIC specification. +
 

--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -184,7 +184,7 @@ instance. For example, in an 4-core system with 2-way SMT, you have 8 harts and 
 at least two privilege modes per hart: machine mode and supervisor mode.
 (ref: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/Documentation/devicetree/bindings/interrupt-controller/sifive%2Cplic-1.0.0.yaml)
 
-However PLIC organizes interrupts for the contexts (Hart and privilege mode) 
+How PLIC organizes interrupts for the contexts (Hart and privilege mode) 
 is out of RISC-V PLIC specification scope, however it must be spec-out in vendor's 
 PLIC specification. +
 

--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -176,16 +176,17 @@ Each global interrupt can be enabled by setting the corresponding bit in the
 `enables` register. The `enables` registers are accessed as a contiguous array
 of 32-bit registers, packed the same way as the `pending` bits. Bit 0 of enable
 register 0 represents the non-existent interrupt ID 0 and is hardwired to 0.
-PLIC has 15872 Interrupt Enable blocks for the contexts. The `context` is referred 
+PLIC has 15872 Interrupt Enable blocks for the contexts. 
+
+The `context` is referred 
 to the specific privilege mode in the specific Hart of specific RISC-V processor 
-instance. How PLIC organizes interrupts for the contexts (Hart and privilege mode) 
+instance. For example, in an 4-core system with 2-way SMT, you have 8 harts and probably
+at least two privilege modes per hart: machine mode and supervisor mode.
+(ref: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/Documentation/devicetree/bindings/interrupt-controller/sifive%2Cplic-1.0.0.yaml)
+
+How PLIC organizes interrupts for the contexts (Hart and privilege mode) 
 is out of RISC-V PLIC specification scope, however it must be spec-out in vendor's 
 PLIC specification. +
-	
-	A hart context is a privilege mode in a hardware execution thread. For example,
-	in an 4 core system with 2-way SMT, you have 8 harts and probably at least two
-	priviledge modes per hart: machine mode and supervisor mode.
-	(ref: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/Documentation/devicetree/bindings/interrupt-controller/sifive%2Cplic-1.0.0.yaml) 
 
 The base address of Interrupt Enable Bits block within PLIC Memory Map region is fixed at 0x002000. +
  +


### PR DESCRIPTION
When reading the spec about the PLIC on riscv ISA, I had some trouble understanding what the 'context' is referred to.  
So I searched for its meaning in the internet, then found some descriptions about it from `linux `repo.  
There' s the link: https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/Documentation/devicetree/bindings/interrupt-controller/sifive%2Cplic-1.0.0.yaml  
I think adding some descriptions about the `context` will help us understand this document better, so create this pr.  
Hope for being merged.  