### PR TITLE
Update riscv-plic.adoc

### DIFF
--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -7,7 +7,7 @@ This RISC-V PLIC specification is
 [%hardbreaks]
 (C) 2017 Drew Barbier <drew@sifive.com>
 (C) 2018-2019 Palmer Dabbelt <palmer@sifive.com>
-(C) 2019 Abner Chang, Hewlett Packard Enterprise <abner.chang@hpe.com>
+(C) 2019-2021 Abner Chang, Hewlett Packard Enterprise <abner.chang@hpe.com>
 
 It is licensed under the Creative Commons Attribution 4.0 International
 License (CC-BY 4.0).  The full license text is available at
@@ -20,9 +20,12 @@ specification, which defines an interrupt controller specifically designed to
 work in the context of RISC-V systems.  The PLIC multiplexes various device
 interrupts onto the external interrupt lines of Hart contexts, with
 hardware support for interrupt priorities. +
-This specification defines the general PLIC architecture and operation parameters.
-The PLIC which claimed as PLIC-Compliant standard PLIC should follow the
-implementations mentioned in sections below.
+This specification defines the general PLIC architecture and the operation
+parameters. PLIC supports up-to 1024 interrupts and 15872 contexts, but the
+actual number of interrupts and context depends on the PLIC implementation.
+However, the implement must adhere to the offset of each register within the
+PLIC operation parameters. The PLIC which claimed as PLIC-Compliant standard
+PLIC should follow the implementations mentioned in sections below.
 
 .Figure 1 RISC-V PLIC Interrupt Architecture Block Diagram
 image::Images/PLIC.jpg[GitHub,1000,643, link=https://github.com/riscv/riscv-plic-spec/blob/master/Images/PLIC.jpg]


### PR DESCRIPTION
Add description of the supported interrupt number
and the hart contexts.

Signed-off-by: Abner Chang <abner.chang@hpe.com>
Reviewed-by: Alistair Francis <alistair.francis@wdc.com>
Reviewed-by: Atish Patra <atish.patra@wdc.com>