### PR TITLE
Add more descriptions for Interrupt Completion section

### DIFF
--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -482,6 +482,11 @@ interrupt ID it received from the claim to the `claim/complete` register.  The
 PLIC does not check whether the completion ID is the same as the last claim ID
 for that target.  If the completion ID does not match an interrupt source that
 is currently enabled for the target, the completion is silently ignored. +
+After a handler has completed service of an interrupt, the associated gateway
+must be sent an interrupt completion message, usually as a write to a
+non-idempotent memory-mapped I/O control register. The gateway will only forward
+additional interrupts to the PLIC core after receiving the completion message. +
+ +
 The Interrupt Completion registers are context based and located at the same address 
 with Interrupt Claim Process register, which is at (4K alignment + 4) starts from
 offset 0x200000.


### PR DESCRIPTION
The additional description is copied from original PLIC spec in
RISC-V privilege v1.9.