### PR TITLE
Reword introduction

### DIFF
--- a/introduction.adoc
+++ b/introduction.adoc
@@ -8,14 +8,9 @@
 
 == Introduction
 
-This specification delineates the operation parameters according the general PLIC
-architecture defined in the RISC-V platform-level interrupt controller (PLIC)
-specification (was removed from https://github.com/riscv/riscv-isa-manual/releases/download/draft-20181201-5449851/riscv-privileged.pdf[RISC-V Privileged Spec v1.11-draft])
-to work in the context of RISC-V systems. +
-The PLIC multiplexes various device interrupts onto the external interrupt lines
-of Hart contexts, with hardware support for interrupt priorities. PLIC supports
-up-to 1023 interrupts (0 is reserved) and 15872 contexts, but the actual number of
-interrupts and context depends on the PLIC implementation. However, the implementation
-must adhere to the offset of each register within the PLIC operation parameters.
-The PLIC which claimed as PLIC-Compliant standard PLIC should follow the 
-implementations mentioned in sections below.
+This document specifies the Platform-Level Interrupt Controller (PLIC). PLIC is
+designed to work in the context of RISC-V systems and allows various
+device interrupts to be multiplexed onto the external interrupt lines of one or
+more Hart contexts, with hardware support for interrupt priorities. PLIC supports
+up-to 1023 interrupts (0 is reserved) and 15872 contexts. The actual number of
+interrupts and context depends on the PLIC implementation.


### PR DESCRIPTION
This introduction was quite weirdly worded, so I:

* Removed reference to the fact that this was once in a very old version of the priv spec. Not really relevant now.
* Removed the bit about "delineating operation parameters" (not clear what that meant).
* Removed the redundant statement about PLIC-compliant implementations having to conform to this document.
* Removed the bit about registers - I think that's fairly obvious and not really needed in the introduction.

Hopefully this reads a bit better.