### PR TITLE
Fix PLIC/target typo in interrupt completion section and remove redundant paragraph     

### DIFF
--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -101,28 +101,28 @@ image::PLIC.jpg[400,432,align="center"]
 
 === Interrupt Gateways
 
-The interrupt gateways are responsible for converting global interrupt signals 
+The interrupt gateways are responsible for converting global interrupt signals
 into a common interrupt request format, and for controlling the flow of interrupt
 requests to the PLIC core. At most one interrupt request per interrupt source can
 be pending in the PLIC core at any time, indicated by setting the source's IP bit.
-The gateway only forwards a new interrupt request to the PLIC core after receiving 
+The gateway only forwards a new interrupt request to the PLIC core after receiving
 notification that the interrupt handler servicing the previous interrupt request
 from the same source has completed. +
-If the global interrupt source uses level-sensitive interrupts, the gateway will 
+If the global interrupt source uses level-sensitive interrupts, the gateway will
 convert the first assertion of the interrupt level into an interrupt request, but
 thereafter the gateway will not forward an additional interrupt request until it
 receives an interrupt completion message. On receiving an interrupt completion
 message, if the interrupt is level-triggered and the interrupt is still asserted, a
 new interrupt request will be forwarded to the PLIC core. The gateway does not
-have the facility to retract an interrupt request once forwarded to the PLIC core. 
+have the facility to retract an interrupt request once forwarded to the PLIC core.
 If a level-sensitive interrupt source deasserts the interrupt after the PLIC core
 accepts the request and before the interrupt is serviced, the interrupt request
 remains present in the IP bit of the PLIC core and will be serviced by a handler,
 which will then have to determine that the interrupt device no longer requires
 service. +
 If the global interrupt source was edge-triggered, the gateway will convert the
-first matching signal edge into an interrupt request. Depending on the design of 
-the device and the interrupt handler, in between sending an interrupt request and 
+first matching signal edge into an interrupt request. Depending on the design of
+the device and the interrupt handler, in between sending an interrupt request and
 receiving notice of its handler's completion, the gateway might either ignore
 additional matching edges or increment a counter of pending interrupts. In either
 case, the next interrupt request will not be forwarded to the PLIC core until the
@@ -207,7 +207,7 @@ General PLIC operation parameter register blocks are defined in this spec, those
 
 - *Interrupt Pending Bits registers:* +
    The interrupt pending status of each interrupt source. +
-   
+
 - *Interrupt Enables registers:* +
    The enablement of interrupt source of each context. +
 
@@ -216,7 +216,7 @@ General PLIC operation parameter register blocks are defined in this spec, those
 
 - *Interrupt Claim registers:* +
    The register to acquire interrupt source ID of each context. +
-   
+
 - *Interrupt Completion registers:* +
    The register to send interrupt completion message to the associated gateway. +
 
@@ -241,24 +241,24 @@ registers specified in this chapter have a width of 32-bits. The bits are access
 	base + 0x000FFC: Interrupt source 1023 priority
 	base + 0x001000: Interrupt Pending bit 0-31
 	base + 0x00107C: Interrupt Pending bit 992-1023
-	...	
+	...
 	base + 0x002000: Enable bits for sources 0-31 on context 0
 	base + 0x002004: Enable bits for sources 32-63 on context 0
 	...
 	base + 0x00207C: Enable bits for sources 992-1023 on context 0
 	base + 0x002080: Enable bits for sources 0-31 on context 1
-	base + 0x002084: Enable bits for sources 32-63 on context 1	
+	base + 0x002084: Enable bits for sources 32-63 on context 1
 	...
 	base + 0x0020FC: Enable bits for sources 992-1023 on context 1
 	base + 0x002100: Enable bits for sources 0-31 on context 2
-	base + 0x002104: Enable bits for sources 32-63 on context 2	
+	base + 0x002104: Enable bits for sources 32-63 on context 2
 	...
 	base + 0x00217C: Enable bits for sources 992-1023 on context 2
 	...
 	base + 0x1F1F80: Enable bits for sources 0-31 on context 15871
-	base + 0x1F1F84: Enable bits for sources 32-63 on context 15871		
+	base + 0x1F1F84: Enable bits for sources 32-63 on context 15871
 	base + 0x1F1FFC: Enable bits for sources 992-1023 on context 15871
-	...	
+	...
 	base + 0x1FFFFC: Reserved
 	base + 0x200000: Priority threshold for context 0
 	base + 0x200004: Claim/complete for context 0
@@ -271,9 +271,9 @@ registers specified in this chapter have a width of 32-bits. The bits are access
 	base + 0x3FFF000: Priority threshold for context 15871
 	base + 0x3FFF004: Claim/complete for context 15871
 	base + 0x3FFF008: Reserved
-	...	
+	...
 	base + 0x3FFFFFC: Reserved
-	
+
 Sections below describe the control register blocks of PLIC operation parameters.
 
 == Interrupt Priorities
@@ -306,7 +306,7 @@ The base address of Interrupt Source Priority block within PLIC Memory Map regio
 |Interrupt Source Priority
 |Interrupt Source Priority #0 to #1023
 |1024 * 4 = 4096(0x1000) bytes
-|This is a continuously memory block which contains PLIC Interrupt Source Priority. Total 1024 Interrupt Source Priority 
+|This is a continuously memory block which contains PLIC Interrupt Source Priority. Total 1024 Interrupt Source Priority
 in this memory block. Interrupt Source Priority #0 is reserved which indicates it does not exist.
 |===
 
@@ -354,8 +354,8 @@ Each global interrupt can be enabled by setting the corresponding bit in the
 of 32-bit registers, packed the same way as the `pending` bits. Bit 0 of enable
 register 0 represents the non-existent interrupt ID 0 and is hardwired to 0.
 PLIC has 15872 Interrupt Enable blocks for the contexts. +
-How PLIC organizes interrupts for the contexts (Hart and privilege mode) 
-is out of RISC-V PLIC specification scope, however it must be spec-out in vendor's 
+How PLIC organizes interrupts for the contexts (Hart and privilege mode)
+is out of RISC-V PLIC specification scope, however it must be spec-out in vendor's
 PLIC specification. +
 (_A large number of potential IE bits might be hardwired to zero in cases where
 some interrupt sources can only be routed to a subset of targets. A larger number
@@ -372,8 +372,8 @@ fixed at 0x002000. +
 |Interrupt Enable Bits
 |Interrupt Enable Bit of Interrupt Source #0 to #1023 for 15872 contexts
 |(1024 / 8) * 15872 = 2031616(0x1f0000) bytes
-|This is a continuously memory block contains PLIC Interrupt Enable Bits of 15872 contexts. 
-Each Interrupt Enable Bit occupies 1-bit from this register block and total 15872 Interrupt 
+|This is a continuously memory block contains PLIC Interrupt Enable Bits of 15872 contexts.
+Each Interrupt Enable Bit occupies 1-bit from this register block and total 15872 Interrupt
 Enable Bit blocks
 |===
 
@@ -394,14 +394,14 @@ Enable Bit blocks
 	...
 	...
 	...
-	0x1F1F80: Interrupt Source #0 to #31 on context 15871	
-	...	
+	0x1F1F80: Interrupt Source #0 to #31 on context 15871
+	...
 	0x1F1FFC: Interrupt Source #992 to #1023 on context 15871
-	
+
 == Priority Thresholds
 
-PLIC provides context based `threshold register` for the settings of a interrupt priority 
-threshold of each context. The `threshold register` is a WARL field. The PLIC will mask all 
+PLIC provides context based `threshold register` for the settings of a interrupt priority
+threshold of each context. The `threshold register` is a WARL field. The PLIC will mask all
 PLIC interrupts of a priority less than or equal to `threshold`.  For example,
 a `threshold` value of zero permits all interrupts with non-zero priority. +
  +
@@ -427,7 +427,7 @@ from offset 0x200000.
 	...
 	...
 	0x3FFF000: Priority threshold for context 15871
-	
+
 == Interrupt Claim Process
 
 Sometime after a target receives an interrupt notification, it might decide to
@@ -437,7 +437,10 @@ control register read. On receiving a claim message, the PLIC core will atomical
 determine the ID of the highest-priority pending interrupt for the target
 and then clear down the corresponding source’s IP bit. The PLIC core will then
 return the ID to the target. The PLIC core will return an ID of zero, if there
-were no pending interrupts for the target when the claim was serviced. +
+were no pending interrupts for the target when the claim was serviced.
+The target can perform a claim at any time and the claim operation is not affected
+by the setting of the priority threshold register. +
++
 After the highest-priority pending interrupt is claimed by a target and the
 corresponding IP bit is cleared, other lower-priority pending interrupts might
 then become visible to the target, and so the PLIC EIP bit might not be cleared
@@ -450,13 +453,7 @@ notifications and instead poll for active interrupts using periodic claim reques
 though a simpler approach to implement polling would be to clear the external
 interrupt enable in the corresponding xie register for privilege mode x. +
 
-The PLIC can perform an interrupt claim by reading the `claim/complete`
-register, which returns the ID of the highest priority pending interrupt or
-zero if there is no pending interrupt.  A successful claim will also atomically
-clear the corresponding pending bit on the interrupt source. The PLIC can perform a claim at any time and the claim operation is not affected
-by the setting of the priority threshold register. +
- +
-The Interrupt Claim Process register is context based and is located at 
+The Interrupt Claim Process register is context based and is located at
 (4K alignment + 4) starts from offset 0x200000.
 [cols="15%,20%,20%,45%"]
 |===
@@ -477,10 +474,10 @@ The Interrupt Claim Process register is context based and is located at
 	...
 	...
 	0x3FFF004: Interrupt Claim Process for context 15871
-	
+
 ## Interrupt Completion
 
-The PLIC signals it has completed executing an interrupt handler by writing the
+The target signals it has completed executing an interrupt handler by writing the
 interrupt ID it received from the claim to the `claim/complete` register.  The
 PLIC does not check whether the completion ID is the same as the last claim ID
 for that target.  If the completion ID does not match an interrupt source that
@@ -490,7 +487,7 @@ must be sent an interrupt completion message, usually as a write to a
 non-idempotent memory-mapped I/O control register. The gateway will only forward
 additional interrupts to the PLIC core after receiving the completion message. +
  +
-The Interrupt Completion registers are context based and located at the same address 
+The Interrupt Completion registers are context based and located at the same address
 with Interrupt Claim Process register, which is at (4K alignment + 4) starts from
 offset 0x200000.
  +


### PR DESCRIPTION
The current text says that the PLIC writes to the claim/complete register on completion but that doesn't really make sense. It should be the target that writes to it.
    
There's also a paragraph in the *Interrupt Claim Process* section that is mostly redundant and contains the same PLIC/target mixup, so I removed it.

Fixes #53 