### PR TITLE
Improve wording of "context-based"

### DIFF
--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -456,8 +456,8 @@ zero if there is no pending interrupt.  A successful claim will also atomically
 clear the corresponding pending bit on the interrupt source. The PLIC can perform a claim at any time and the claim operation is not affected
 by the setting of the priority threshold register. +
  +
-The Interrupt Claim Process register is context based and is located at 
-(4K alignment + 4) starts from offset 0x200000.
+There is one Interrupt Claim Process register for each context, located at
+(4K alignment + 4) starting from offset 0x200000.
 [cols="15%,20%,20%,45%"]
 |===
 | *PLIC Register Block Name* | *Function*|*Register Block Size in Byte*| *Description*
@@ -490,8 +490,8 @@ must be sent an interrupt completion message, usually as a write to a
 non-idempotent memory-mapped I/O control register. The gateway will only forward
 additional interrupts to the PLIC core after receiving the completion message. +
  +
-The Interrupt Completion registers are context based and located at the same address 
-with Interrupt Claim Process register, which is at (4K alignment + 4) starts from
+There is one Interrupt Completion register for each context, located at the same address
+as the Interrupt Claim Process register, which is at (4K alignment + 4) starting from
 offset 0x200000.
  +
 [cols="15%,20%,20%,45%"]


### PR DESCRIPTION
It's not clear what "context-based" means here. It's just trying to say there's one register per context, so say that instead.