### PR TITLE
Clarify interrupt claim signalling to gateway

### DIFF
--- a/riscv-plic.adoc
+++ b/riscv-plic.adoc
@@ -485,10 +485,10 @@ interrupt ID it received from the claim to the `claim/complete` register.  The
 PLIC does not check whether the completion ID is the same as the last claim ID
 for that target.  If the completion ID does not match an interrupt source that
 is currently enabled for the target, the completion is silently ignored. +
-After a handler has completed service of an interrupt, the associated gateway
-must be sent an interrupt completion message, usually as a write to a
-non-idempotent memory-mapped I/O control register. The gateway will only forward
-additional interrupts to the PLIC core after receiving the completion message. +
+If the completion ID matches an interrupt source that is currently enabled
+for the target then the corresponding gateway for that source is notified of
+the completion.  The gateway will only forward
+additional interrupts to the PLIC core after receiving this notification. +
  +
 The Interrupt Completion registers are context based and located at the same address 
 with Interrupt Claim Process register, which is at (4K alignment + 4) starts from


### PR DESCRIPTION
The existing text was weirdly worded, making it sound like the PLIC core has to somehow notify the gateways via a second MMIO register write. Actually it's just an internal notification wire.